### PR TITLE
feat: use ScrapingUrl name in notification header instead of ScrappingTarget name

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,9 +16,9 @@
 - `just quality-check`: run Ruff lint/format checks and mypy.
 - `just coverage`: run backend coverage report.
 - `docker compose up`: run local stack in containers.
-- `npm --prefix frontend run dev`: start frontend on port `3000`.
-- `npm --prefix frontend run test`: run frontend Vitest suite.
-- `npm --prefix frontend run lint`: run TypeScript + ESLint checks.
+- `pnpm -C frontend dev`: start frontend on port `3000`.
+- `pnpm -C frontend test`: run frontend Vitest suite.
+- `pnpm -C frontend lint`: run TypeScript + ESLint checks.
 
 ## Coding Style & Naming Conventions
 - Python: 4-space indentation, max line length 120, `snake_case` for modules/functions.

--- a/shargain/notifications/services/notifications.py
+++ b/shargain/notifications/services/notifications.py
@@ -24,10 +24,16 @@ class NotificationMessageContext:
 
 
 class NewOfferNotificationService:
-    def __init__(self, message_contexts: list[NotificationMessageContext], scrapping_target: ScrappingTarget):
+    def __init__(
+        self,
+        message_contexts: list[NotificationMessageContext],
+        scrapping_target: ScrappingTarget,
+        notification_title: str,
+    ):
         assert scrapping_target.notification_config_id, "Scrapping target has no notification_config"  # noqa: S101
         self.message_contexts = message_contexts
         self._scrapping_target = scrapping_target
+        self.notification_title = notification_title
 
     def run(self):
         message = self.get_message_header()
@@ -76,4 +82,4 @@ class NewOfferNotificationService:
         return base_msg + "\n\n"
 
     def get_message_header(self):
-        return f"{self._scrapping_target.name.upper()}\n\n"
+        return f"{self.notification_title.upper()}\n\n"

--- a/shargain/notifications/tests/services/test_notifications.py
+++ b/shargain/notifications/tests/services/test_notifications.py
@@ -13,10 +13,10 @@ from shargain.offers.tests.factories import OfferFactory, ScrappingTargetFactory
 @pytest.mark.django_db
 class TestGetMessageForOffer:
     @staticmethod
-    def _make_service():
+    def _make_service(notification_title="TEST TARGET"):
         config = NotificationConfigFactory()
         target = ScrappingTargetFactory(notification_config=config)
-        return NewOfferNotificationService([], target)
+        return NewOfferNotificationService([], target, notification_title)
 
     def test_message_includes_distances_when_provided(self):
         offer = OfferFactory.build()
@@ -56,3 +56,19 @@ class TestGetMessageForOffer:
 
         assert "km from" not in msg
         assert "m from" not in msg
+
+
+@pytest.mark.django_db
+class TestGetMessageHeader:
+    @staticmethod
+    def _make_service(notification_title="TEST TARGET"):
+        config = NotificationConfigFactory()
+        target = ScrappingTargetFactory(notification_config=config)
+        return NewOfferNotificationService([], target, notification_title)
+
+    def test_message_header_uses_provided_title(self):
+        service = self._make_service("MY CUSTOM TITLE")
+        header = service.get_message_header()
+
+        assert "MY CUSTOM TITLE" in header
+        assert header == "MY CUSTOM TITLE\n\n"

--- a/shargain/notifications/tests/services/test_notifications.py
+++ b/shargain/notifications/tests/services/test_notifications.py
@@ -13,10 +13,10 @@ from shargain.offers.tests.factories import OfferFactory, ScrappingTargetFactory
 @pytest.mark.django_db
 class TestGetMessageForOffer:
     @staticmethod
-    def _make_service(notification_title="TEST TARGET"):
+    def _make_service():
         config = NotificationConfigFactory()
         target = ScrappingTargetFactory(notification_config=config)
-        return NewOfferNotificationService([], target, notification_title)
+        return NewOfferNotificationService([], target, "NOTIFICATION TITLE")
 
     def test_message_includes_distances_when_provided(self):
         offer = OfferFactory.build()

--- a/shargain/offers/services/batch_create.py
+++ b/shargain/offers/services/batch_create.py
@@ -189,4 +189,7 @@ class OfferBatchCreateService:
                 )
 
             # Call notification service per group
-            self.notification_service_class(message_contexts, scrapping_target).run()
+            notification_title = scraping_url.name if scraping_url else scrapping_target.name
+            self.notification_service_class(
+                message_contexts, scrapping_target, notification_title=notification_title
+            ).run()


### PR DESCRIPTION
## Summary
Changes notification service to use the ScrapingUrl name (URL-specific name) instead of the ScrappingTarget name in notification headers.

## Changes
1. **shargain/notifications/services/notifications.py**: Added required `notification_title` parameter to `NewOfferNotificationService.__init__()` and used it in `get_message_header()`
2. **shargain/offers/services/batch_create.py**: In `_notify()`, computes title from `scraping_url.name` (fallback to `scrapping_target.name` if no URL) and passes to notification service
3. **shargain/notifications/tests/services/test_notifications.py**: Updated tests to require `notification_title` parameter and added test for custom header title
