### PR TITLE
feat: show parking type in notifications via RichValue

### DIFF
--- a/shargain/notifications/services/notifications.py
+++ b/shargain/notifications/services/notifications.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass, field
 
 from shargain.notifications.models import NotificationChannelChoices
 from shargain.notifications.senders import TelegramNotificationSender
-from shargain.offers.field_extraction import ExtractedFieldEntry
+from shargain.offers.field_extraction import ExtractedFieldEntry, RichValue
 from shargain.offers.models import Offer, ScrappingTarget
 
 
@@ -31,7 +31,12 @@ class NotificationMessageContext:
         for entry in self.extracted_fields:
             if entry.value is None:
                 continue
-            if isinstance(entry.value, bool):
+            if isinstance(entry.value, RichValue):
+                if entry.value.display is not None:
+                    display = entry.value.display
+                else:
+                    display = "Yes" if entry.value.get_value() else "No"
+            elif isinstance(entry.value, bool):
                 display = "Yes" if entry.value else "No"
             else:
                 display = str(entry.value)

--- a/shargain/notifications/tests/services/test_notifications.py
+++ b/shargain/notifications/tests/services/test_notifications.py
@@ -7,7 +7,7 @@ from shargain.notifications.services.notifications import (
     NotificationMessageContext,
 )
 from shargain.notifications.tests.factories import NotificationConfigFactory
-from shargain.offers.field_extraction import ExtractedFieldEntry
+from shargain.offers.field_extraction import ExtractedFieldEntry, RichValue
 from shargain.offers.tests.factories import ScrappingTargetFactory
 
 
@@ -90,6 +90,12 @@ class TestExtractedFieldsInMessage:
                 ],
                 ["42.5", "4", "No", "Great location"],
             ),
+            (
+                [ExtractedFieldEntry(name="parking", value=RichValue(True, "przynależne na ulicy, w garażu"))],
+                ["przynależne na ulicy, w garażu"],
+            ),
+            ([ExtractedFieldEntry(name="parking", value=RichValue(True))], ["Yes"]),
+            ([ExtractedFieldEntry(name="parking", value=RichValue(False))], ["No"]),
         ],
     )
     def test_extracted_fields_rendered(self, fields, assertions, notification_service, offer):

--- a/shargain/offers/field_extraction/__init__.py
+++ b/shargain/offers/field_extraction/__init__.py
@@ -8,6 +8,7 @@ from shargain.offers.field_extraction.plugin import (
     ListUrl,
     NotificationFieldsSelection,
     Operator,
+    RichValue,
 )
 from shargain.offers.field_extraction.plugins import registered_plugins
 from shargain.offers.field_extraction.resolver import OfferFieldResolver, get_operators_for_type
@@ -23,6 +24,7 @@ __all__ = [
     "NotificationFieldsSelection",
     "OfferFieldResolver",
     "Operator",
+    "RichValue",
     "get_operators_for_type",
     "registered_plugins",
 ]

--- a/shargain/offers/field_extraction/plugin.py
+++ b/shargain/offers/field_extraction/plugin.py
@@ -16,7 +16,21 @@ if TYPE_CHECKING:
 
     from shargain.offers.models import Offer
 
-ExtractedFieldValue = int | float | str | bool | None
+ExtractedScalar = bool | int | float | str | None
+
+
+@dataclass(frozen=True)
+class RichValue:
+    """Wrapper carrying a filterable scalar plus an optional display string."""
+
+    value: ExtractedScalar
+    display: str | None = None
+
+    def get_value(self) -> ExtractedScalar:
+        return self.value
+
+
+ExtractedFieldValue = ExtractedScalar | RichValue
 
 ListUrl = NewType("ListUrl", str)
 

--- a/shargain/offers/field_extraction/plugins/olx_apartment.py
+++ b/shargain/offers/field_extraction/plugins/olx_apartment.py
@@ -11,6 +11,7 @@ from shargain.offers.field_extraction.plugin import (
     FieldDefinition,
     FieldType,
     ListUrl,
+    RichValue,
 )
 
 if TYPE_CHECKING:
@@ -85,19 +86,16 @@ def _extract_winda(extra: dict) -> bool | None:
     return value == "Tak"
 
 
-def _extract_parking(extra: dict) -> bool | None:
+def _extract_parking(extra: dict) -> RichValue | None:
     entry = _param(extra, "parking")
     if entry is None:
         return None
     value = _normalized(entry)
     if value is None:
         return None
-    if isinstance(value, list):
-        choices = value
-    else:
-        choices = [value]
-    has_parking = any(choice != "brak" for choice in choices if isinstance(choice, str))
-    return has_parking
+    choices = value if isinstance(value, list) else [value]
+    labels = [choice for choice in choices if isinstance(choice, str) and choice != "brak"]
+    return RichValue(value=bool(labels), display=", ".join(labels) if labels else None)
 
 
 def _extract_text(extra: dict, key: str) -> str | None:

--- a/shargain/offers/filtering/service.py
+++ b/shargain/offers/filtering/service.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from typing import Any, NotRequired, TypedDict
 
-from shargain.offers.field_extraction.plugin import ExtractedOffer, Operator
+from shargain.offers.field_extraction.plugin import ExtractedOffer, Operator, RichValue
 
 
 class FilterRuleData(TypedDict):
@@ -75,6 +75,8 @@ class OfferFilterService:
         filter_value = rule["value"]
 
         field_value = offer.fields.get(field_name)
+        if isinstance(field_value, RichValue):
+            field_value = field_value.get_value()
         if field_value is None:
             return False
 

--- a/shargain/offers/tests/services/test_filter_service.py
+++ b/shargain/offers/tests/services/test_filter_service.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from shargain.offers.field_extraction import ExtractedOffer
+from shargain.offers.field_extraction import ExtractedOffer, RichValue
 from shargain.offers.filtering import FilterOperator, OfferFilterService
 
 
@@ -270,6 +270,21 @@ class TestOfferFilterService:
         filtered = service.apply([offer_with_elevator, offer_unknown, offer_no_field])
 
         assert filtered == [offer_with_elevator]
+
+    def test_rich_value_unwrapped_for_filtering(self):
+        offer_with_parking = ExtractedOffer(_offer=None, fields={"parking": RichValue(True, "przynależne na ulicy")})
+        offer_without_parking = ExtractedOffer(_offer=None, fields={"parking": RichValue(False)})
+        offer_unknown = ExtractedOffer(_offer=None, fields={"parking": RichValue(None)})
+        service = OfferFilterService(
+            {
+                "ruleGroups": [
+                    {"rules": [{"field": "parking", "operator": FilterOperator.EQUALS.value, "value": "True"}]}
+                ]
+            }
+        )
+        filtered = service.apply([offer_with_parking, offer_without_parking, offer_unknown])
+
+        assert filtered == [offer_with_parking]
 
     def test_filter_title_equals(self, offer_apartment, offer_studio):
         service = OfferFilterService(

--- a/shargain/offers/tests/services/test_olx_apartment_plugin.py
+++ b/shargain/offers/tests/services/test_olx_apartment_plugin.py
@@ -1,6 +1,6 @@
 """Tests for OlxApartmentPlugin."""
 
-from shargain.offers.field_extraction import FieldType, ListUrl
+from shargain.offers.field_extraction import FieldType, ListUrl, RichValue
 from shargain.offers.field_extraction.plugins.olx_apartment import olx_apartment
 from shargain.offers.tests.factories import OfferFactory
 
@@ -67,7 +67,7 @@ class TestOlxApartmentPluginExtract:
         assert result["floor"] == 2
         assert result["rooms"] == 2
         assert result["winda"] is True
-        assert result["parking"] is True
+        assert result["parking"] == RichValue(True, "przynależne na ulicy")
         assert result["builttype"] == "blok"
         assert result["market"] == "secondary"
 
@@ -112,7 +112,7 @@ class TestOlxApartmentPluginExtract:
 
     def test_parking_brak_is_false(self):
         offer = OfferFactory.build(metadata=_params({"key": "parking", "value": "brak", "normalizedValue": ["brak"]}))
-        assert olx_apartment.extract(offer, OLX_URL)["parking"] is False
+        assert olx_apartment.extract(offer, OLX_URL)["parking"] == RichValue(False)
 
     def test_parking_brak_with_other_choices_is_true(self):
         offer = OfferFactory.build(
@@ -120,7 +120,25 @@ class TestOlxApartmentPluginExtract:
                 {"key": "parking", "value": "brak, identyfikator", "normalizedValue": ["brak", "identyfikator"]}
             )
         )
-        assert olx_apartment.extract(offer, OLX_URL)["parking"] is True
+        assert olx_apartment.extract(offer, OLX_URL)["parking"] == RichValue(True, "identyfikator")
+
+    def test_parking_multiple_choices_joined_in_display(self):
+        offer = OfferFactory.build(
+            metadata=_params(
+                {
+                    "key": "parking",
+                    "value": "przynależne na ulicy, w garażu",
+                    "normalizedValue": ["przynależne na ulicy", "w garażu"],
+                }
+            )
+        )
+        assert olx_apartment.extract(offer, OLX_URL)["parking"] == RichValue(True, "przynależne na ulicy, w garażu")
+
+    def test_parking_scalar_choice(self):
+        offer = OfferFactory.build(
+            metadata=_params({"key": "parking", "value": "parking strzeżony", "normalizedValue": "parking strzeżony"})
+        )
+        assert olx_apartment.extract(offer, OLX_URL)["parking"] == RichValue(True, "parking strzeżony")
 
     def test_parking_missing_is_none(self):
         offer = OfferFactory.build(metadata={"extra": {}})


### PR DESCRIPTION
## Summary
OLX apartment listings expose `parking` as a boolean for filtering, but the source data carries the actual parking type (e.g. "przynależne na ulicy", "w garażu"). This PR introduces a `RichValue` wrapper that carries both the filterable scalar and an optional display string, and uses it for the OLX `parking` field so Telegram notifications show the parking type instead of a bare Yes/No.

## Changes
- `field_extraction/plugin.py`: new `RichValue` (frozen dataclass with `value` + `display` + `get_value()`); `ExtractedFieldValue = ExtractedScalar | RichValue`; exported from `field_extraction/__init__.py`
- `olx_apartment.py`: `_extract_parking` returns `RichValue(bool, display)` — display joins all parking types except `brak`; `["brak"]` → `RichValue(False)`
- `filtering/service.py`: unwraps `RichValue` via `get_value()` before the `None` check (before the case-insensitive branch)
- `notifications.py`: renderer shows `display` when set, otherwise Yes/No from the boolean value
- Otodom parking stays a plain boolean (Yes/No) — no change

## Test evidence
- `just test`: **270 passed**
- `just quality-check`: ruff format/check + mypy clean (0 issues)

## Story
Follow-up to #49 (OLX/Otodom apartment field plugins).