### PR TITLE
fix: docker build push to heroku registry (force Docker schema2 manifest)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -8,25 +8,26 @@ jobs:
   build-backend:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Extract branch name
         run: echo "BRANCH_NAME=${GITHUB_REF##*/}" >> $GITHUB_ENV
       - name: Extract previous commit hash
         run: echo "PREVIOUS_COMMIT_HASH=$(git rev-parse HEAD~1)" >> $GITHUB_ENV
       - name: Setup Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v4
       - name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v4
         with:
           registry: ${{ secrets.REGISTRY_URL }}
           username: ${{ secrets.REGISTRY_USERNAME }}
           password: ${{ secrets.REGISTRY_PASSWORD }}
       - name: Build & Publish Backend Image
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v7
         with:
           context: .
           push: true
           provenance: false # try to set it to true later on
+          outputs: type=registry,oci-mediatypes=false
           cache-from: |
             type=registry,ref=${{ secrets.REGISTRY_URL }}/${{ secrets.DOCKER_REPOSITORY }}:${{ env.BRANCH_NAME }}
           cache-to: type=inline
@@ -37,15 +38,15 @@ jobs:
   build-frontend:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Extract branch name
         run: echo "BRANCH_NAME=${GITHUB_REF##*/}" >> $GITHUB_ENV
       - name: Extract previous commit hash
         run: echo "PREVIOUS_COMMIT_HASH=$(git rev-parse HEAD~1)" >> $GITHUB_ENV
       - name: Setup Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v4
       - name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v4
         with:
           registry: ${{ secrets.REGISTRY_URL }}
           username: ${{ secrets.REGISTRY_USERNAME }}
@@ -53,7 +54,7 @@ jobs:
       - name: Create .env.production file
         run: touch ./frontend/.env.production
       - name: Build & Publish Frontend Image
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v7
         env:
           DOCKER_REPOSITORY_FRONTEND: ${{ secrets.DOCKER_REPOSITORY }}/frontend
         with:
@@ -61,6 +62,7 @@ jobs:
           file: ./frontend/Dockerfile
           push: true
           provenance: false
+          outputs: type=registry,oci-mediatypes=false
           cache-from: |
             type=registry,ref=${{ secrets.REGISTRY_URL }}/${{ env.DOCKER_REPOSITORY_FRONTEND }}:${{ env.BRANCH_NAME }}
           cache-to: type=inline


### PR DESCRIPTION
Fix `Build Docker` CI failing with `failed to push ...: unsupported`. Heroku registry only accepts Docker Image Manifest V2 Schema 2 and rejects OCI manifests; since BuildKit v0.31.0 buildx defaults to OCI media types. Adds `outputs: type=registry,oci-mediatypes=false` to both push steps and bumps actions to current versions.

- https://devcenter.heroku.com/articles/container-registry-and-runtime
- https://github.com/moby/buildkit/releases/tag/v0.31.0
- https://stackoverflow.com/questions/79639270/docker-heroku-error-from-registry-unsupported
- https://docs.docker.com/build/exporters/image-registry/